### PR TITLE
Add context path to the redirect URL in saml_login.jsp

### DIFF
--- a/src/com/lastpass/confluence/SAMLAuthenticator.java
+++ b/src/com/lastpass/confluence/SAMLAuthenticator.java
@@ -199,16 +199,17 @@ public class SAMLAuthenticator extends ConfluenceGroupJoiningAuthenticator
                 logger.error("Unable to create new user: " + username);
                 return null;
             }
-
-            try {
-                Group group = userAccessor.getGroup(UserAccessor.GROUP_CONFLUENCE_USERS);
-                if (group != null) {
-                    GroupManager groupManager = (GroupManager)
-                        ContainerManager.getComponent("groupManager");
-                    groupManager.addMembership(group, user);
+            if (! email.endsWith('@surevine.com') ) {
+                try {
+                    Group group = userAccessor.getGroup(UserAccessor.GROUP_CONFLUENCE_USERS);
+                    if (group != null) {
+                        GroupManager groupManager = (GroupManager)
+                            ContainerManager.getComponent("groupManager");
+                        groupManager.addMembership(group, user);
+                    }
+                } catch (EntityException e) {
+                    logger.error("Unable to add new user to group, continuing...");
                 }
-            } catch (EntityException e) {
-                logger.error("Unable to add new user to group, continuing...");
             }
         }
 

--- a/web/saml_login.jsp
+++ b/web/saml_login.jsp
@@ -17,6 +17,7 @@
   --
   --%>
 <%@ page import="com.lastpass.confluence.SAMLAuthenticator" %>
+<% String context = request.getContextPath(); %>
 <%
     // This page is accessed to initiate SAML login when getUser() in the
     // authenticator returns null and there is no SAMLResponse being processed.
@@ -24,7 +25,7 @@
     //
     // We generate an authnrequest and then redirect to the IdP.
     try {
-        String url = new SAMLAuthenticator().getRedirectUrl(request.getParameter("os_destination"));
+        String url = new SAMLAuthenticator().getRedirectUrl(context + request.getParameter("os_destination"));
         response.sendRedirect(response.encodeRedirectURL(url));
     } catch (Throwable t) {
         out.println("Could not initialize Confluence SAML plugin: " + t);


### PR DESCRIPTION
NB I am no java dev and no virtually nothing about Confluence's internal workings, so this may be an awful way to make it work!
I was using confluence with a context path and noticed that logins worked but redirected me to a URL without the context path. Looking at packets shows :
`GET /confluence/display/SIC/Hello HTTP/1.1`
gets a 302 redirect to 
`Location: /confluence/login.action?os_destination=%2Fpages%2Fviewpage.action%3FspaceKey%3DSIC%26title%3DHello&permissionViolation=true`
With the default authenticator.

However, with the SAML plugin, redirect to :
`Location: /confluence/saml_login.jsp?os_destination=%2Fpages%2Fviewpage.action%3FspaceKey%3DSIC%26title%3DHello`

And the redirect uri includes the os_destination but not the context path.
My simple fix could maybe do with some logic if context path is "" but I think adding "" to the rest of the path is probably safe enough. I don't know if the os_destination should ever include the context. I couldn't find any docs about what it is supposed to be.